### PR TITLE
3 define cli command structure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.0.1"
 edition = "2024"
 
 [dependencies]
-clap = { version = "4.5.37", features = ["derive"] }
+clap = { version = "4.5.37", features = ["derive", "env"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,10 @@ use clap::{Args, Parser, Subcommand};
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+
+    /// Notion integration token
+    #[arg(long, env, hide_env_values = true)]
+    token: String,
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
 #[command(arg_required_else_help = true)]
 struct Cli {
@@ -8,20 +8,63 @@ struct Cli {
     command: Commands,
 }
 
-#[derive(Subcommand)]
+#[derive(Debug, Subcommand)]
 enum Commands {
-    /// test command
-    Test {
-        /// string for echo
-        test_string: String,
-    },
+    /// Show the list of databases
+    DbList,
+    /// Show the structure of the database matching the id specified by the argument
+    DbView(DbViewArgs),
+    /// Add the item to the database specified with id
+    DbAdd(DbAddArgs),
+}
+
+#[derive(Debug, Args)]
+struct DbViewArgs {
+    /// Target database id
+    id: String,
+}
+
+#[derive(Debug, Args)]
+struct DbAddArgs {
+    /// Target database id
+    id: String,
+    #[clap(flatten)]
+    item: DbItemGroup,
+}
+
+#[derive(Debug, Args)]
+#[group(required = true, multiple = false)]
+pub struct DbItemGroup {
+    /// specify the item to add with json string
+    #[clap(long)]
+    json: Option<String>,
+    /// specify the item to add with the file contents
+    #[clap(long)]
+    file_path: Option<String>,
 }
 
 fn main() {
     let cli = Cli::parse();
     match &cli.command {
-        Commands::Test { test_string } => {
-            println!("test_string is {}", test_string);
+        Commands::DbList => {
+            println!("the list of databases will be displayed here");
+        }
+        Commands::DbView(args) => {
+            println!(
+                "the structure of the database whose id is {} will be displayed here",
+                args.id
+            );
+        }
+        Commands::DbAdd(args) => {
+            println!(
+                "the bellow item will be added to the database whose id is {} here",
+                args.id
+            );
+            if let Some(json) = &args.item.json {
+                println!("{}", json)
+            } else if let Some(path) = &args.item.file_path {
+                println!("the contents of {}", path)
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ pub struct DbItemGroup {
 
 fn main() {
     let cli = Cli::parse();
+    println!("specified token is {}", cli.token);
     match &cli.command {
         Commands::DbList => {
             println!("the list of databases will be displayed here");


### PR DESCRIPTION
Following commands has been defined although not implemented.

* `notion-cli-rs db-list`
* `notion db-view <ID>`
* `notion db-add <ID> <--json <JSON> | --file-path <FILE_PATH>>`

The behavior is as shown bellow:

![image](https://github.com/user-attachments/assets/1b8e2d89-716a-4edf-8a34-1d921154fe36)

The Notion integration token must be received from environment variable or a `--token` option.